### PR TITLE
Update build properties to enable Dynatrace OneAgent code instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as builder
+FROM golang:1.17.10-alpine as builder
 
 ARG TARGETPLATFORM
 ARG REVISON
@@ -17,7 +17,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # build
-RUN CGO_ENABLED=0 go build \
+RUN CGO_ENABLED=1 go build \
     -ldflags "-s -w -X github.com/fluxcd/flagger/pkg/version.REVISION=${REVISON}" \
     -a -o flagger ./cmd/flagger
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION?=$(shell grep 'VERSION' pkg/version/version.go | awk '{ print $$4 }' | t
 LT_VERSION?=$(shell grep 'VERSION' cmd/loadtester/main.go | awk '{ print $$4 }' | tr -d '"' | head -n1)
 
 build:
-	CGO_ENABLED=0 go build -a -o ./bin/flagger ./cmd/flagger
+	CGO_ENABLED=1 go build -a -o ./bin/flagger ./cmd/flagger
 
 fmt:
 	go mod tidy


### PR DESCRIPTION
Making minor tweaks to Dockerfile and Makefile to satisfy OneAgent requirements for deep code instrumentation.
https://techhub.shipt.com/engineering/infrastructure/site-reliability/dynatrace/#instrumentation-requirements

[_Created by Sourcegraph batch change `ShiptDevopsApps/dynatrace-oneagent-enabling-build-properties`._](https://shipt.sourcegraph.com/users/ShiptDevopsApps/batch-changes/dynatrace-oneagent-enabling-build-properties)